### PR TITLE
Fix: start app crash on MacOS. Directory /tmp/log does not exist

### DIFF
--- a/app/app_config/config_service.py
+++ b/app/app_config/config_service.py
@@ -27,6 +27,7 @@ NOTE: You should only change it if you understand what you're doing.
 import datetime
 import logging
 from logging.handlers import TimedRotatingFileHandler
+import os
 
 
 class ConfService:
@@ -184,6 +185,12 @@ class ConfService:
     log_file_info = "logs.log"
 
     backup_count = 7
+
+    # check if the log directory exists
+    try:
+        os.makedirs(log_dir)
+    except FileExistsError:
+        pass
 
     log_handler_info = TimedRotatingFileHandler(
         filename=f"{log_dir}/{log_file_info}",


### PR DESCRIPTION
## Description

App crash when running by following the instructions. 

`flask --app app run `

Is resulting in

```bash

(eduiw-py) ➜  app git:(main) ✗ flask --app app run
Traceback (most recent call last):
  File "/opt/homebrew/bin/flask", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/flask/cli.py", line 1064, in main
    cli.main()
  File "/opt/homebrew/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/flask/cli.py", line 912, in run_command
    raise e from None
  File "/opt/homebrew/lib/python3.11/site-packages/flask/cli.py", line 898, in run_command
    app = info.load_app()
          ^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/flask/cli.py", line 309, in load_app
    app = locate_app(import_name, name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/flask/cli.py", line 219, in locate_app
    __import__(module_name)
  File "/Users/aridder/Projects/eudi-srv-web-issuing-eudiw-py/app/__init__.py", line 42, in <module>
    from .app_config.config_service import ConfService as log
  File "/Users/aridder/Projects/eudi-srv-web-issuing-eudiw-py/app/app_config/config_service.py", line 32, in <module>
    class ConfService:
  File "/Users/aridder/Projects/eudi-srv-web-issuing-eudiw-py/app/app_config/config_service.py", line 188, in ConfService
    log_handler_info = TimedRotatingFileHandler(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/handlers.py", line 214, in __init__
    BaseRotatingHandler.__init__(self, filename, 'a', encoding=encoding,
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/handlers.py", line 58, in __init__
    logging.FileHandler.__init__(self, filename, mode=mode,
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1181, in __init__
    StreamHandler.__init__(self, self._open())
                                 ^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1213, in _open
    return open_func(self.baseFilename, self.mode,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/log/logs.log'
```

## Background:

`pip list`

```bash
(eduiw-py) ➜  app git:(fix/fix_startup_logs_error) ✗ pip list                                  
Package                   Version
------------------------- ---------
annotated-types           0.6.0
anyio                     4.3.0
asn1crypto                1.5.1
attrs                     23.2.0
blinker                   1.7.0
cached-property           1.5.2
cachelib                  0.12.0
cbor-diag                 1.0.1
cbor2                     5.4.6
certifi                   2024.2.2
certvalidator             0.11.1
cffi                      1.16.0
charset-normalizer        3.3.2
click                     8.1.7
config                    0.5.1
cryptography              41.0.7
cryptojwt                 1.8.3
cwt                       2.3.2
distlib                   0.3.7
distro                    1.9.0
ecdsa                     0.18.0
fedservice                4.0.0
filelock                  3.12.4
Flask                     2.3.3
Flask-API                 3.1
Flask-Cors                4.0.0
Flask-Session             0.6.0
gunicorn                  21.2.0
h11                       0.14.0
httpcore                  1.0.4
httpx                     0.27.0
idna                      3.6
idpyoidc                  3.0.0
idpysdjwt                 0.0.1
itsdangerous              2.1.2
Jinja2                    3.1.3
jsonschema                4.21.1
jsonschema-specifications 2023.12.1
jwcrypto                  1.5.6
MarkupSafe                2.1.5
numpy                     1.26.3
openai                    1.13.3
openid4v                  0.0.1
oscrypto                  1.3.0
packaging                 24.0
pillow                    10.2.0
pip                       24.0
platformdirs              3.11.0
pycose                    1.0.1
pycparser                 2.21
pycryptodome              3.20.0
pydantic                  2.6.3
pydantic_core             2.16.3
pyhpke                    0.5.2
pyignite                  0.6.1
PyJWT                     2.8.0
pymdoccbor                0.5.4
pyOpenSSL                 24.1.0
python-pkcs11             0.7.0
pytz                      2024.1
PyYAML                    6.0.1
referencing               0.33.0
requests                  2.31.0
responses                 0.25.0
rpds-py                   0.18.0
schedule                  1.2.1
sd-jwt                    0.10.4
setuptools                69.0.2
six                       1.16.0
sniffio                   1.3.1
tinyec                    0.4.0
tqdm                      4.66.2
typing_extensions         4.10.0
urllib3                   2.2.1
validators                0.22.0
virtualenv                20.24.5
Werkzeug                  2.3.7
wheel                     0.42.0

```