### PR TITLE
Add date validation for issue_date and expiry_date for doc_type org.iso.18013.5.1.mDL

### DIFF
--- a/app/app_config/config_service.py
+++ b/app/app_config/config_service.py
@@ -172,6 +172,7 @@ class ConfService:
         "303": "Error obtaining attributes.",
         "304": "PID attribute(s) missing.",
         "305": "Certificate not available.",
+        "306": "Date is not in the correct format. Should be YYYY-MM-DD.",
         "401": "Missing mandatory formatter fields.",
         "501": "Missing mandatory IdP fields",
     }

--- a/app/tests/test_route_formatter.py
+++ b/app/tests/test_route_formatter.py
@@ -83,10 +83,10 @@ def test_cbor_formatter_error_401():
                     "Type": "B"
                     }
                 ],
-                "expiry_date": "Fri, 25 Aug 2023 10:15:53 GMT",
+                "expiry_date": "2023-08-28",
                 "family_name": "Lima",
                 "given_name": "João",
-                "issue_date": "Wed, 26 Jul 2023 10:15:53 GMT",
+                "issue_date": "2023-07-26",
                 "issuing_authority": "IMTT-Lisboa",
                 "issuing_country": "PT",
                 "portrait": "/9j/4AAQSkZJRgABAQAAAQAB...",
@@ -196,7 +196,7 @@ def test_cbor_formatter_error_306_date_formatting():
                     "Type": "B"
                     }
                 ],
-                "expiry_date": "Fri, 25 Aug 2023 10:15:53 GMT",
+                "expiry_date": "2023-08-28",
                 "family_name": "Lima",
                 "given_name": "João",
                 "issue_date": "2024-01-01",

--- a/app/tests/test_route_formatter.py
+++ b/app/tests/test_route_formatter.py
@@ -121,10 +121,10 @@ def test_cbor_formatter_error_401_country():
                     "Type": "B"
                     }
                 ],
-                "expiry_date": "Fri, 25 Aug 2023 10:15:53 GMT",
+                "expiry_date": "2024-12-31",
                 "family_name": "Lima",
                 "given_name": "João",
-                "issue_date": "Wed, 26 Jul 2023 10:15:53 GMT",
+                "issue_date": "2024-01-01",
                 "issuing_authority": "IMTT-Lisboa",
                 "issuing_country": "PT",
                 "portrait": "/9j/4AAQSkZJRgABAQAAAQAB...",
@@ -158,10 +158,10 @@ def test_cbor_formatter_error_401_doctype():
                     "Type": "B"
                     }
                 ],
-                "expiry_date": "Fri, 25 Aug 2023 10:15:53 GMT",
+                "expiry_date": "2024-12-31",
                 "family_name": "Lima",
                 "given_name": "João",
-                "issue_date": "Wed, 26 Jul 2023 10:15:53 GMT",
+                "issue_date": "2024-01-01",
                 "issuing_authority": "IMTT-Lisboa",
                 "issuing_country": "PT",
                 "portrait": "/9j/4AAQSkZJRgABAQAAAQAB...",
@@ -174,6 +174,44 @@ def test_cbor_formatter_error_401_doctype():
     
     assert response.json()["error_code"] == 401
     assert response.json()["error_message"] == "Missing mandatory formatter fields."
+    assert response.json()["mdoc"] == ''
+
+#   expiry_date is not in the correct format
+def test_cbor_formatter_error_306_date_formatting():
+
+    payload_306_D = {
+        "version":"0.2",
+        "country":"PT",
+        "device_publickey": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFOElFUUJqNENaZDNZaWZYbmpxUmx0SUlpSkQ2VwpoWkV4RWtQVWdQUnkvWXd1ZUZzSk42UGVod3F0dlUxRnoyMG5XOVpjVUxLem9LaVdnaGlOeTM4NTBBPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t",
+        "data": {
+            "org.iso.18013.5.1": {
+                "birth_date": "13-12-2000",
+                "birth_place": "Lisboa",
+                "document_number": "18923",
+                "driving_privileges": [
+                    {
+                    "ExpiryDate": "2099-12-31",
+                    "IssueDate": "2000-01-01",
+                    "Restriction": [],
+                    "Type": "B"
+                    }
+                ],
+                "expiry_date": "Fri, 25 Aug 2023 10:15:53 GMT",
+                "family_name": "Lima",
+                "given_name": "João",
+                "issue_date": "2024-01-01",
+                "issuing_authority": "IMTT-Lisboa",
+                "issuing_country": "PT",
+                "portrait": "/9j/4AAQSkZJRgABAQAAAQAB...",
+                "un_distinguishing_sign": "P"
+            }
+        }
+    }
+    
+    response= requests.post(ENDPOINT, json=payload_306_D, verify=False)
+    
+    assert response.json()["error_code"] == 306
+    assert response.json()["error_message"] == "Date is not in the correct format. Should be YYYY-MM-DD."
     assert response.json()["mdoc"] == ''
 
 #   Missing field: data

--- a/app/validate.py
+++ b/app/validate.py
@@ -24,6 +24,7 @@ This validate.py file includes different validation functions.
 """
 
 import base64
+import datetime
 from flask import session
 import validators
 
@@ -224,4 +225,15 @@ def is_valid_pem_public_key(pem_key):
     except Exception as e:
         return False
 
+def validate_date_format(date):
+    """ Validate if date is in the correct format
 
+    Return: Return True or return value.
+    + If date have the correct format , return True.
+    + If date have the incorrect format, return False
+    """
+    try:
+        datetime.datetime.strptime(date, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
Test cases for `cbor/formatter` had malformed dates. The test case tested mandatory fields, so the malformed date format was not handled and misleading.

This PR tries to give a better error message if providing wrong date format.