### PR TITLE
Task/docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-FROM ubuntu:22.04
+FROM python:3.10-slim-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
-    python3.10 \
-    python3.10-venv \
-    python3.10-dev \
-    python3-pip \
     git \
     gcc \
     build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ ENV FLASK_APP=app \
     SERVICE_URL="https://127.0.0.1:5000/" \
     EIDAS_NODE_URL="https://preprod.issuer.eudiw.dev/EidasNode/" \
     DYNAMIC_PRESENTATION_URL="https://dev.verifier-backend.eudiw.dev/ui/presentations/" \
-    SECRETS_CONFIG_DIR="/home/flaskuser/secrets"
+    SECRETS_CONFIG_DIR="/home/flaskuser/secrets" \
+    METADATA_CONFIG_DIR="/home/flaskuser/metadata_config"
+
 # copy entrypoint script to conntainer
 COPY --chown=flaskuser:flaskuser docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN flaskuser:flaskuser /tmp/log_dev
 
 USER flaskuser
 
-RUN git clone https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py.git /root/eudi-srv-web-issuing-eudiw-py
+# install cargo into user land
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/flaskuser/.cargo/bin:${PATH}"
 
 # copy application contents into container
 WORKDIR /home/flaskuser/eudi-srv-web-issuing-eudiw-py

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,13 @@ RUN ./venv/bin/pip install --no-cache-dir -r app/requirements.txt
 
 EXPOSE 5000
 
-ENV FLASK_APP=app\
-    FLASK_RUN_PORT=5000\
-    FLASK_RUN_HOST=0.0.0.0\
+ENV FLASK_APP=app \
+    FLASK_RUN_PORT=5000 \
+    FLASK_RUN_HOST=0.0.0.0 \
     SERVICE_URL="https://127.0.0.1:5000/" \
+    EIDAS_NODE_URL="https://preprod.issuer.eudiw.dev/EidasNode/" \
+    DYNAMIC_PRESENTATION_URL="https://dev.verifier-backend.eudiw.dev/ui/presentations/" \
+    SECRETS_CONFIG_DIR="/home/flaskuser/secrets"
 # copy entrypoint script to conntainer
 COPY --chown=flaskuser:flaskuser docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ ENV FLASK_APP=app\
     FLASK_RUN_PORT=5000\
     FLASK_RUN_HOST=0.0.0.0\
     SERVICE_URL="https://127.0.0.1:5000/" \
-    EIDAS_NODE_URL="https://preprod.issuer.eudiw.dev/EidasNode/"\
-    DYNAMIC_PRESENTATION_URL="https://dev.verifier-backend.eudiw.dev/ui/presentations/"
+# copy entrypoint script to conntainer
+COPY --chown=flaskuser:flaskuser docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-CMD ["sh", "-c", "cp /root/secrets/config_secrets.py /root/eudi-srv-web-issuing-eudiw-py/app/app_config/ && export REQUESTS_CA_BUNDLE=/root/secrets/cert.pem && /root/eudi-srv-web-issuing-eudiw-py/venv/bin/flask run --cert=/root/secrets/cert.pem --key=/root/secrets/key.pem"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,26 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Add a non root user for the application to run on
+RUN groupadd -r flaskuser && useradd -r -g flaskuser flaskuser
+
+RUN mkdir -p /home/flaskuser/eudi-srv-web-issuing-eudiw-py \
+    && chown -R flaskuser:flaskuser /home/flaskuser
+
 RUN mkdir -p /tmp/log_dev
 RUN chmod -R 755 /tmp/log_dev
+RUN flaskuser:flaskuser /tmp/log_dev
+
+USER flaskuser
 
 RUN git clone https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py.git /root/eudi-srv-web-issuing-eudiw-py
 
-WORKDIR /root/eudi-srv-web-issuing-eudiw-py
+# copy application contents into container
+WORKDIR /home/flaskuser/eudi-srv-web-issuing-eudiw-py
+COPY --chown=flaskuser:flaskuser ./app /home/flaskuser/eudi-srv-web-issuing-eudiw-py/app
 
 RUN python3 -m venv venv
-
-RUN /root/eudi-srv-web-issuing-eudiw-py/venv/bin/pip install --no-cache-dir -r app/requirements.txt
+RUN ./venv/bin/pip install --no-cache-dir -r app/requirements.txt
 
 EXPOSE 5000
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ ! -f "$SECRETS_CONFIG_DIR/config_secrets.py" ]; then
+    echo "Error: config_secrets.py not found in $SECRETS_CONFIG_DIR. Exiting."
+    exit 1
+fi
+FLASK_RUN_CMD="./venv/bin/flask run"
+
+if [ -f "$SECRETS_CONFIG_DIR/cert.pem" ] && [ -f "$SECRETS_CONFIG_DIR/key.pem" ]; then
+    export REQUESTS_CA_BUNDLE="$SECRETS_CONFIG_DIR/cert.pem"
+    FLASK_RUN_CMD="$FLASK_RUN_CMD --cert=$SECRETS_CONFIG_DIR/cert.pem --key=$SECRETS_CONFIG_DIR/key.pem"
+else
+    echo "No SSL certificate and key provided, running Flask without SSL."
+fi
+
+eval $FLASK_RUN_CMD

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,9 @@ if [ ! -f "$SECRETS_CONFIG_DIR/config_secrets.py" ]; then
     echo "Error: config_secrets.py not found in $SECRETS_CONFIG_DIR. Exiting."
     exit 1
 fi
+
+cp "$SECRETS_CONFIG_DIR/config_secrets.py" /home/flaskuser/eudi-srv-web-issuing-eudiw-py/app/app_config/
+
 FLASK_RUN_CMD="./venv/bin/flask run"
 
 if [ -f "$SECRETS_CONFIG_DIR/cert.pem" ] && [ -f "$SECRETS_CONFIG_DIR/key.pem" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,11 @@ fi
 
 cp "$SECRETS_CONFIG_DIR/config_secrets.py" /home/flaskuser/eudi-srv-web-issuing-eudiw-py/app/app_config/
 
+if [ -d "$METADATA_CONFIG_DIR" ]; then
+    cp "$METADATA_CONFIG_DIR/metadata_config.json" /home/flaskuser/eudi-srv-web-issuing-eudiw-py/app/metadata_config/
+    cp "$METADATA_CONFIG_DIR/openid-configuration.json" /home/flaskuser/eudi-srv-web-issuing-eudiw-py/app/metadata_config/
+fi
+
 FLASK_RUN_CMD="./venv/bin/flask run"
 
 if [ -f "$SECRETS_CONFIG_DIR/cert.pem" ] && [ -f "$SECRETS_CONFIG_DIR/key.pem" ]; then

--- a/install.md
+++ b/install.md
@@ -205,7 +205,7 @@ To run the EUDIW issuer in Docker please follow these steps:
 
 3. Build the Docker: `sudo docker build -t eudiw-issuer .`
 
-4. Create 2 directories to be mounted:
+4. Create 3 directories to be mounted:
 
    1. First directory named `config_secrets`
       
@@ -220,17 +220,22 @@ To run the EUDIW issuer in Docker please follow these steps:
 
       The `privKey` directory has the Document/Credential signer (DS) private keys
 
+   3. Third directory named `metadata_config` containing the files `metadata_config.json` and `openid-configuration.json`
+
+      Configure them as per [documentation](api_docs/configuration.md) starting with the templates that are already present in the application code
 
     Example:
    
 
     ```bash
     docker-issuer
-    ├── Dockerfile
     ├── config_secrets
     │   ├── config_secrets.py
     │   ├── cert.pem
     │   └── key.pem
+    ├── metadata_config
+    │   ├── metadata_config.json
+    │   └── openid-configuration.json
     └── pid-issuer
         ├── cert
         │   ├── PID-DS-0001_UT_cert.der
@@ -249,7 +254,8 @@ To run the EUDIW issuer in Docker please follow these steps:
     -e SERVICE_URL="https://your.service.url/" \
     -e EIDAS_NODE_URL="https://your.eidas.node.url/" \
     -e DYNAMIC_PRESENTATION_URL="https://your.dynamic.presentation.url/" \
-    -v ./config_secrets:/root/secrets \
+    -v ./config_secrets://home/flaskuser/secrets \
+    -v ./metadata_config://home/flaskuser/metadata_config \
     -v ./pid-issuer:/etc/eudiw/pid-issuer \
     -p 5000:5000 \
     eudiw-issuer


### PR DESCRIPTION
Partially resolves https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/66 by 

* not using ubuntu with the larger attack surface, instead a slimmer python based image
* running as non privileged user
* allowing to overwrite the urls as per https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/blob/main/api_docs/configuration.md#4-metadata-configuration 
* not cloning the whole repo while running docker build, instead copying over the relevant parts into the container
* having a more readable `entrypoint.sh` including a non and an ssl option (depending on whether TLS certs are passed into the container)