### PR TITLE
Rename credential display url to uri to match spec

### DIFF
--- a/app/metadata_config/credentials_supported/booking_registration_mdoc.json
+++ b/app/metadata_config/credentials_supported/booking_registration_mdoc.json
@@ -42,7 +42,7 @@
         "name": "Reservation",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/pid.png",
+          "uri": "https://examplestate.com/public/pid.png",
           "alt_text": "A square figure of a PID"
         }
       }

--- a/app/metadata_config/credentials_supported/hiid_mdoc.json
+++ b/app/metadata_config/credentials_supported/hiid_mdoc.json
@@ -42,7 +42,7 @@
         "name": "Health ID",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/hiid.png",
+          "uri": "https://examplestate.com/public/hiid.png",
           "alt_text": "A square figure of a hiid"
         }
       }

--- a/app/metadata_config/credentials_supported/iban_mdoc.json
+++ b/app/metadata_config/credentials_supported/iban_mdoc.json
@@ -42,7 +42,7 @@
         "name": "IBAN",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/iban.png",
+          "uri": "https://examplestate.com/public/iban.png",
           "alt_text": "A square figure of a iban"
         }
       }

--- a/app/metadata_config/credentials_supported/loyalty_mdoc.json
+++ b/app/metadata_config/credentials_supported/loyalty_mdoc.json
@@ -32,7 +32,7 @@
           "name": "Loyalty",
           "locale": "en",
           "logo": {
-            "url": "https://examplestate.com/public/pid.png",
+            "uri": "https://examplestate.com/public/pid.png",
             "alt_text": "A square figure of a PID"
           }
         }

--- a/app/metadata_config/credentials_supported/mdl_jwt_vc_json.json
+++ b/app/metadata_config/credentials_supported/mdl_jwt_vc_json.json
@@ -31,7 +31,7 @@
         "name": "mDL",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/mdl.png",
+          "uri": "https://examplestate.com/public/mdl.png",
           "alt_text": "A square figure of a mDL"
         }
       }

--- a/app/metadata_config/credentials_supported/mdl_mdoc.json
+++ b/app/metadata_config/credentials_supported/mdl_mdoc.json
@@ -32,7 +32,7 @@
         "name": "mDL",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/mdl.png",
+          "uri": "https://examplestate.com/public/mdl.png",
           "alt_text": "A square figure of a mDL"
         }
       }

--- a/app/metadata_config/credentials_supported/msisdn_mdoc.json
+++ b/app/metadata_config/credentials_supported/msisdn_mdoc.json
@@ -42,7 +42,7 @@
         "name": "MSISDN",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/msisdn.png",
+          "uri": "https://examplestate.com/public/msisdn.png",
           "alt_text": "A square figure of a msisdn"
         }
       }

--- a/app/metadata_config/credentials_supported/photo_id_mdoc.json
+++ b/app/metadata_config/credentials_supported/photo_id_mdoc.json
@@ -32,7 +32,7 @@
         "name": "Photo",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/mdl.png",
+          "uri": "https://examplestate.com/public/mdl.png",
           "alt_text": "A square figure of a mDL"
         }
       }

--- a/app/metadata_config/credentials_supported/pid_jwt_vc_json.json
+++ b/app/metadata_config/credentials_supported/pid_jwt_vc_json.json
@@ -31,7 +31,7 @@
         "name": "PID",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/pid.png",
+          "uri": "https://examplestate.com/public/pid.png",
           "alt_text": "A square figure of a PID"
         }
       }

--- a/app/metadata_config/credentials_supported/pid_mdoc.json
+++ b/app/metadata_config/credentials_supported/pid_mdoc.json
@@ -42,7 +42,7 @@
         "name": "PID",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/pid.png",
+          "uri": "https://examplestate.com/public/pid.png",
           "alt_text": "A square figure of a PID"
         }
       }

--- a/app/metadata_config/credentials_supported/por_mdoc.json
+++ b/app/metadata_config/credentials_supported/por_mdoc.json
@@ -42,7 +42,7 @@
         "name": "Power Of Representation",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/por.png",
+          "uri": "https://examplestate.com/public/por.png",
           "alt_text": "A square figure of a PoR"
         }
       }

--- a/app/metadata_config/credentials_supported/pseudonym_over18_mdoc.json
+++ b/app/metadata_config/credentials_supported/pseudonym_over18_mdoc.json
@@ -32,7 +32,7 @@
           "name": "Age over 18 Pseudonym",
           "locale": "en",
           "logo": {
-            "url": "https://examplestate.com/public/pid.png",
+            "uri": "https://examplestate.com/public/pid.png",
             "alt_text": "A square figure of a Age over 18"
           }
         }

--- a/app/metadata_config/credentials_supported/pseudonym_over18_mdoc_deferred_endpoint.json
+++ b/app/metadata_config/credentials_supported/pseudonym_over18_mdoc_deferred_endpoint.json
@@ -32,7 +32,7 @@
           "name": "Pseudonym Deferred",
           "locale": "en",
           "logo": {
-            "url": "https://examplestate.com/public/pid.png",
+            "uri": "https://examplestate.com/public/pid.png",
             "alt_text": "A square figure of a PID"
           }
         }

--- a/app/metadata_config/credentials_supported/tax_mdoc.json
+++ b/app/metadata_config/credentials_supported/tax_mdoc.json
@@ -42,7 +42,7 @@
         "name": "Tax Number",
         "locale": "en",
         "logo": {
-          "url": "https://examplestate.com/public/tax.png",
+          "uri": "https://examplestate.com/public/tax.png",
           "alt_text": "A square figure of a tax"
         }
       }


### PR DESCRIPTION
As we are supporting [draft 13](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html) we need to update the display url to uri. This is changed from draft 12 to draft 13. 

See this part: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#section-11.2.3