### PR TITLE
#138 Fix invalid version tag in Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   issuer_backend:
-    image: ghcr.io/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py:main
+    image: ghcr.io/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py:latest
     ports:
       - "5000:5000"
     volumes:


### PR DESCRIPTION
Fixes issue #138 by replacing invalid Docker image tag `main` with `latest`.