### PR TITLE
Upgrade the version of python used in 'SAST - SonarCloud - Push/WD analysis' job

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,9 +25,9 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Upgrade the version of python used in 'SAST - SonarCloud - Push/WD analysis' job

* from 3.10 to 3.13